### PR TITLE
Create a sink port if its not present

### DIFF
--- a/include/port_mgr/dpdk/bf_dpdk_port_if.h
+++ b/include/port_mgr/dpdk/bf_dpdk_port_if.h
@@ -126,6 +126,11 @@ typedef enum {
 	BF_DPDK_NUM_COUNTERS,		/*!< Total Number of Counters */
 } port_counters_t;
 
+/**
+ * Create a sink port if required
+ * @return Status of the API call.
+ */
+bf_status_t port_mgr_sink_create(const char *pipe_name);
 #ifdef __cplusplus
 }
 #endif /* C++ */

--- a/src/pipe_mgr/shared/dal/dpdk/dal_init.c
+++ b/src/pipe_mgr/shared/dal/dpdk/dal_init.c
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 #include <osdep/p4_sde_osdep.h>
+#include <port_mgr/dpdk/bf_dpdk_port_if.h>
 
 #include "../dal_init.h"
 #include "../../infra/pipe_mgr_int.h"
@@ -69,6 +70,13 @@ int dal_enable_pipeline(bf_dev_id_t dev_id,
 		LOG_ERROR("dpdk pipeline %s get failed",
 				profile->pipeline_name);
 		return BF_OBJECT_NOT_FOUND;
+	}
+
+	status = port_mgr_sink_create(profile->pipeline_name);
+	if (status) {
+		LOG_ERROR("sink creation Error %d at line %u: %s\n.",
+			status, __LINE__, __func__);
+		return BF_INTERNAL_ERROR;
 	}
 
 	status = rte_swx_pipeline_build_from_spec(pipe->p,


### PR DESCRIPTION
Create a sink port if its not present before enabling the pipeline.
This will fix the functionality of drop action configured by user
getting redirected to last port added on pipe line.

Signed-off-by: Vishnu Swaroop Kumar Sarma, Duddu <duddu.swaroop@intel.com>