### PR TITLE
Fix char comparison to EOF

### DIFF
--- a/src/pipe_mgr/core/pipe_mgr_cli.c
+++ b/src/pipe_mgr/core/pipe_mgr_cli.c
@@ -46,7 +46,7 @@ CLISH_PLUGIN_SYM(version_cmd) {
   }
 
   char c = fgetc(fptr);
-  while (c != EOF) {
+  while (!feof(fptr)) {
     bfshell_printf(clish_context, "%c", c);
     c = fgetc(fptr);
   }


### PR DESCRIPTION
In `arm64`:
`char c = fgetc(fptr); while (c != EOF) {...}` causes `pipe_mgr/core/pipe_mgr_cli.c:49:12: error: comparison is always true due to limited range of data type [-Werror=type-limits]`

Fix using `(!feof(fptr)) {...}`

Fixes https://github.com/p4lang/p4-dpdk-target/issues/13