### PR TITLE
DPDK: Use generic CPU instructions and skip AVX512

### DIFF
--- a/src/lld/dpdk/Makefile.am
+++ b/src/lld/dpdk/Makefile.am
@@ -1,8 +1,13 @@
 all:
 	$(shell ./apply_patch.sh > /dev/null 2>&1)
 	stat dpdk_src/build > /dev/null 2>&1 || \
-	(cd dpdk_src && meson -Dprefix=$(prefix) build && \
-	cd build && ninja -j48 && ninja install)
+	(cd dpdk_src && meson -Dcpu_instruction_set=generic -Dprefix=$(prefix) build && \
+	cd build && sed -e 's/RTE_CPUFLAG_AVX512BW\,//' -i rte_build_config.h && \
+	sed -e 's/RTE_CPUFLAG_AVX512CD\,//' -i rte_build_config.h && \
+	sed -e 's/RTE_CPUFLAG_AVX512DQ\,//' -i rte_build_config.h && \
+	sed -e 's/RTE_CPUFLAG_AVX512F\,//' -i rte_build_config.h && \
+	sed -e 's/RTE_CPUFLAG_AVX512VL\,//' -i rte_build_config.h && \
+	ninja -j48 && ninja install)
 	$(MAKE) -C infra install_dir=$(prefix)
 	cp infra/build/dpdk_infra.so $(libdir)/libdpdk_infra.so
 install:


### PR DESCRIPTION
This commits removes AVX512 support and enables generic CPU options for
the DPDK build. The IPDK CI builds on Azure VMs which support AVX512.
However, since Virtualbox doesn't support this (see [1] and [2]), we
can skip this for p4-dpdk-target when building DPDK as a part of the
p4-dpdk-target repo.

Fixes: https://github.com/ipdk-io/ipdk/issues/118

[1] https://forums.virtualbox.org/viewtopic.php?t=86047
[2] https://forums.virtualbox.org/viewtopic.php?f=7&t=87131

Signed-off-by: Kyle Mestery <mestery@mestery.com>