### PR TITLE
Fixed duplicate definition for struct hotplug_attributes_t.

### DIFF
--- a/include/bf_pal/bf_pal_port_intf.h
+++ b/include/bf_pal/bf_pal_port_intf.h
@@ -24,7 +24,7 @@
 #define SOCK_IP_LEN 64
 #define SOCK_PATH_LEN 256
 #define MAC_STR_LEN 18
-
+#if 0
 /**
  * DPDK Hotplug attributes
  */
@@ -38,6 +38,7 @@ struct hotplug_attributes_t {
 	char native_socket_path[SOCK_PATH_LEN];
 	bool qemu_hotplug;
 };
+#endif
 
 /**
  * @brief Port add function


### PR DESCRIPTION
one in include/port_mgr/dpdk/bf_dpdk_port_if.h (removed)
and another one in include/bf_pal/bf_pal_port_intf.h (keep)