### PR TITLE
Add support for compile mode pipeline

### DIFF
--- a/bf_switchd/bf_switchd.c
+++ b/bf_switchd/bf_switchd.c
@@ -76,6 +76,8 @@
 ******************************************************************************/
 #include "bf_switchd.h"
 
+#define BUF_SIZE 64
+
 /* Global defines */
 bool is_skip_p4 = false;
 
@@ -1655,6 +1657,7 @@ int bf_switchd_lib_init_local(void *ctx_local) {
   int ret = 0;
   bf_dev_id_t dev_id = 0;
   int num_active_devices = 0;
+  char buf[BUF_SIZE];
 
   if (ctx) {
     if ((switchd_ctx = malloc(sizeof(bf_switchd_context_t))) == NULL) {
@@ -1686,6 +1689,13 @@ int bf_switchd_lib_init_local(void *ctx_local) {
     pthread_setname_np(switchd_ctx->dev_sts_t_id, "bf_device_sts");
   }
   #endif
+
+  snprintf(buf, sizeof(buf), "rm %s", IOSPEC_FILE_PATH);
+  ret = system(buf);
+  if (ret) {
+	  printf("%s line:%d Fail to delete %s file\n"
+		 , __func__, __LINE__, IOSPEC_FILE_PATH);
+  }
 
   /* Initialize system services */
   ret = bf_switchd_sys_init();

--- a/include/port_mgr/bf_port_if.h
+++ b/include/port_mgr/bf_port_if.h
@@ -26,6 +26,9 @@ extern "C" {
 
 #include "port_mgr/dpdk/bf_dpdk_port_if.h"
 
+#define IOSPEC_FILE_PATH "/tmp/iospec.io"
+int write_to_iospec_file(char *buf);
+
 /**
  * @file bf_port_if.h
  * \brief Details Port-level APIs.

--- a/src/lld/dpdk/apply_patch.sh
+++ b/src/lld/dpdk/apply_patch.sh
@@ -17,7 +17,7 @@
 
 apply_patch()
 {
-	local PATCH_FILES=(007-Fix-pipeline-structs-initialization.patch)
+	local PATCH_FILES=(007-Fix-pipeline-structs-initialization.patch 0001-Copy-required-header-file-to-install-include-path.patch)
 
 	DPDK_PATH=${PWD}
 	DPDK_SRC_PATH="${DPDK_PATH}"/dpdk_src

--- a/src/lld/dpdk/infra/dpdk_cli.c
+++ b/src/lld/dpdk/infra/dpdk_cli.c
@@ -999,46 +999,85 @@ cmd_pipeline_build(char **tokens,
 	char *out,
 	size_t out_size)
 {
-	struct pipeline *p = NULL;
-	FILE *spec = NULL;
-	uint32_t err_line;
-	const char *err_msg;
-	int status;
+	char *pipeline_name, *lib_file_name, *iospec_file_name;
+	struct rte_swx_ctl_pipeline *ctl = NULL;
+	struct rte_swx_pipeline *p = NULL;
+	FILE *iospec_file = NULL;
+	uint32_t numa_node = 0;
+	int status = 0;
 
-	if (n_tokens != 4) {
+	/* Parsing. */
+	if (n_tokens != 9) {
 		snprintf(out, out_size, MSG_ARG_MISMATCH, tokens[0]);
 		return;
 	}
 
-	p = pipeline_find(tokens[1]);
-	if (!p || p->ctl) {
-		snprintf(out, out_size, MSG_ARG_INVALID, tokens[0]);
+	pipeline_name = tokens[1];
+
+	if (strcmp(tokens[2], "build")) {
+		snprintf(out, out_size, MSG_ARG_NOT_FOUND, "build");
 		return;
 	}
 
-	spec = fopen(tokens[3], "r");
-	if (!spec) {
-		snprintf(out, out_size, "Cannot open file %s.\n", tokens[3]);
+	if (strcmp(tokens[3], "lib")) {
+		snprintf(out, out_size, MSG_ARG_NOT_FOUND, "lib");
 		return;
 	}
 
-	status = rte_swx_pipeline_build_from_spec(p->p,
-		spec,
-		&err_line,
-		&err_msg);
-	fclose(spec);
+	lib_file_name = tokens[4];
+
+	if (strcmp(tokens[5], "io")) {
+		snprintf(out, out_size, MSG_ARG_NOT_FOUND, "io");
+		return;
+	}
+
+	iospec_file_name = tokens[6];
+
+	if (strcmp(tokens[7], "numa")) {
+		snprintf(out, out_size, MSG_ARG_NOT_FOUND, "numa");
+		return;
+	}
+
+	if (parser_read_uint32(&numa_node, tokens[8])) {
+		snprintf(out, out_size, MSG_ARG_INVALID, "numa_node");
+		return;
+	}
+
+	if (parser_read_uint32(&numa_node, tokens[8])) {
+		snprintf(out, out_size, MSG_ARG_INVALID, "numa_node");
+		return;
+	}
+
+	/* I/O spec file open. */
+	iospec_file = fopen(iospec_file_name, "r");
+	if (!iospec_file) {
+		snprintf(out, out_size, "Cannot open file \"%s\".\n",
+			 iospec_file_name);
+		return;
+	}
+
+	status = rte_swx_pipeline_build_from_lib(&p,
+						 pipeline_name,
+						 lib_file_name,
+						 iospec_file,
+						 (int)numa_node);
 	if (status) {
-		snprintf(out, out_size, "Error %d at line %u: %s\n.",
-			status, err_line, err_msg);
-		return;
+		snprintf(out, out_size, "Pipeline build failed (%d).", status);
+		goto free;
 	}
 
-	p->ctl = rte_swx_ctl_pipeline_create(p->p);
-	if (!p->ctl) {
+	ctl = rte_swx_ctl_pipeline_create(p);
+	if (!ctl) {
 		snprintf(out, out_size, "Pipeline control create failed.");
-		rte_swx_pipeline_free(p->p);
-		return;
+		goto free;
 	}
+
+free:
+	if (p)
+		rte_swx_pipeline_free(p);
+
+	if (iospec_file)
+		fclose(iospec_file);
 }
 
 #ifndef MAX_LINE_SIZE

--- a/src/lld/dpdk/infra/dpdk_infra.h
+++ b/src/lld/dpdk/infra/dpdk_infra.h
@@ -185,6 +185,7 @@ struct pipeline {
 	int enabled;
 	uint32_t thread_id;
 	uint32_t cpu_id;
+	uint32_t numa_node;
 	uint64_t net_port_mask[4];
 };
 

--- a/src/lld/dpdk/infra/dpdk_obj.c
+++ b/src/lld/dpdk/infra/dpdk_obj.c
@@ -560,11 +560,6 @@ pipeline_create(const char *name, int numa_node)
 		pipeline_find(name))
 		return NULL;
 
-	/* Resource create */
-	status = rte_swx_pipeline_config(&p, numa_node);
-	if (status)
-		goto error;
-
 	/* Node allocation */
 	pipeline = calloc(1, sizeof(struct pipeline));
 	if (pipeline == NULL)
@@ -574,6 +569,7 @@ pipeline_create(const char *name, int numa_node)
 	strlcpy(pipeline->name, name, sizeof(pipeline->name));
 	pipeline->p = p;
 	pipeline->timer_period_ms = 10;
+	pipeline->numa_node = numa_node;
 
 	/* Node add to list */
 	TAILQ_INSERT_TAIL(&obj->pipeline_list, pipeline, node);

--- a/src/lld/dpdk/patch/0001-Copy-required-header-file-to-install-include-path.patch
+++ b/src/lld/dpdk/patch/0001-Copy-required-header-file-to-install-include-path.patch
@@ -1,0 +1,31 @@
+From 6640176f819e729b26f325b89a7a8db1915f86ba Mon Sep 17 00:00:00 2001
+From: Anand Sunkad <anand.sunkad@intel.com>
+Date: Mon, 26 Sep 2022 22:59:41 +1000
+Subject: [PATCH] Copy required header file to install/include path
+
+Adding required header file names in meson.build file
+to copy into $SDE_INSTALL/include path.
+this patch is required only for SDE, no need to push
+this patch to dpdk opensource.
+
+Signed-off-by: Anand Sunkad <anand.sunkad@intel.com>
+---
+ lib/pipeline/meson.build | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/lib/pipeline/meson.build b/lib/pipeline/meson.build
+index 3ca98ed194..658dbba7c2 100644
+--- a/lib/pipeline/meson.build
++++ b/lib/pipeline/meson.build
+@@ -20,6 +20,8 @@ headers = files(
+         'rte_port_in_action.h',
+         'rte_table_action.h',
+         'rte_swx_pipeline.h',
++        'rte_swx_pipeline_spec.h',
++        'rte_swx_pipeline_internal.h',
+         'rte_swx_extern.h',
+         'rte_swx_ctl.h',
+ )
+-- 
+2.21.3
+

--- a/unit-test/lld/dpdk/lld_dpdk_lib_ut1.cpp
+++ b/unit-test/lld/dpdk/lld_dpdk_lib_ut1.cpp
@@ -42,9 +42,6 @@ TEST(MIRROR_DPDK, case0) {
 	mir_params.n_slots = 4;
 	mir_params.n_sessions = 16;
 
-	EXPECT_GLOBAL_CALL(rte_swx_pipeline_mirroring_config, rte_swx_pipeline_mirroring_config(_,_))
-		.Times(1).
-		WillOnce(Return(0));
 	actual_res = lld_dpdk_pipeline_mirror_config(NULL, &mir_params);
 	expected_res = 0;
 

--- a/unit-test/lld/dpdk/lld_dpdk_port_ut1.cpp
+++ b/unit-test/lld/dpdk/lld_dpdk_port_ut1.cpp
@@ -141,3 +141,138 @@ TEST(NetPortMask, case2) {
     ASSERT_EQ(actual_result, expected_result);
 
 }
+
+TEST(CompileMode, case0) {
+   struct pipeline *pipe_in, *pipe_out, pipe;
+    struct port_attributes_t port_attrib;
+    struct mempool mempool;
+    struct rte_mempool m;
+    struct tap tap;
+    bf_dev_port_t dev_port;
+    int expected_result, ret;
+    memset(&pipe, 0, sizeof(struct pipeline));
+    mempool.m = &m;
+    strcpy(mempool.m->name,"MEMPOOL2");
+    port_attrib.port_dir = PM_PORT_DIR_DEFAULT;
+    port_attrib.port_in_id = 0;
+    port_attrib.port_out_id = 0;
+    port_attrib.tap.mtu = 1500;
+    tap.fd = 32;
+    dev_port = 0;
+    pipe_in = &pipe;
+    pipe_out = &pipe;
+
+    EXPECT_GLOBAL_CALL(tap_find, tap_find(_))
+	    .Times(1).
+	    WillOnce(Return(&tap));
+
+    //Function call
+    ret = lld_dpdk_pipeline_tap_port_add(dev_port, &port_attrib, pipe_in, pipe_out, &mempool);
+    expected_result = 0;
+
+    //Macro checking expected result against the actual result
+    ASSERT_EQ(ret, expected_result);
+
+}
+
+TEST(CompileMode, case1) {
+   struct pipeline *pipe_in, *pipe_out, pipe;
+    struct port_attributes_t port_attrib;
+    struct link link;
+    bf_dev_port_t dev_port;
+    int expected_result, ret;
+    memset(&pipe, 0, sizeof(struct pipeline));
+    strcpy(link.dev_name,"link");
+    port_attrib.port_dir = PM_PORT_DIR_DEFAULT;
+    port_attrib.port_in_id = 0;
+    port_attrib.port_out_id = 0;
+    dev_port = 0;
+    pipe_in = &pipe;
+    pipe_out = &pipe;
+
+    EXPECT_GLOBAL_CALL(link_find, link_find(_))
+	    .Times(1).
+	    WillOnce(Return(&link));
+
+    //Function call
+    ret = lld_dpdk_pipeline_link_port_add(dev_port, &port_attrib, pipe_in, pipe_out);
+    expected_result = 0;
+
+    //Macro checking expected result against the actual result
+    ASSERT_EQ(ret, expected_result);
+
+}
+
+TEST(CompileMode, case2) {
+    struct pipeline *pipe_in, pipe;
+    struct port_attributes_t port_attrib;
+    struct mempool mempool;
+    struct rte_mempool m;
+    bf_dev_port_t dev_port;
+    int expected_result, ret;
+    memset(&pipe, 0, sizeof(struct pipeline));
+    strcpy(port_attrib.source.file_name,"./source.file");
+    port_attrib.port_in_id = 4;
+    mempool.m = &m;
+    strcpy(mempool.m->name,"MEMPOOL2");
+    dev_port = 4;
+    pipe_in = &pipe;
+
+    //Function call
+    ret = lld_dpdk_source_port_add(dev_port, &port_attrib, pipe_in, &mempool);
+    expected_result = 0;
+
+    //Macro checking expected result against the actual result
+    ASSERT_EQ(ret, expected_result);
+
+}
+
+TEST(CompileMode, case3) {
+   struct pipeline *pipe_out, pipe;
+    struct port_attributes_t port_attrib;
+    bf_dev_port_t dev_port;
+    int expected_result, ret;
+    memset(&pipe, 0, sizeof(struct pipeline));
+    strcpy(port_attrib.sink.file_name,"./sink.file");
+    port_attrib.port_out_id = 4;
+    dev_port = 4;
+    pipe_out = &pipe;
+
+    //Function call
+    ret = lld_dpdk_sink_port_add(dev_port, &port_attrib, pipe_out);
+    expected_result = 0;
+
+    //Macro checking expected result against the actual result
+    ASSERT_EQ(ret, expected_result);
+
+}
+
+TEST(CompileMode, case4) {
+   struct pipeline *pipe_in, *pipe_out, pipe;
+    struct port_attributes_t port_attrib;
+    struct mempool mempool;
+    struct ring ring;
+    bf_dev_port_t dev_port;
+    int expected_result, ret;
+    memset(&pipe, 0, sizeof(struct pipeline));
+    strcpy(ring.name,"RING_0");
+    strcpy(port_attrib.port_name,"RING");
+    port_attrib.port_dir = PM_PORT_DIR_DEFAULT;
+    port_attrib.port_in_id = 4;
+    port_attrib.port_out_id = 4;
+    dev_port = 4;
+    pipe_in = &pipe;
+    pipe_out = &pipe;
+
+    EXPECT_GLOBAL_CALL(ring_find, ring_find(_))
+	    .Times(1).
+	    WillOnce(Return(&ring));
+
+    //Function call
+    ret = lld_dpdk_pipeline_ring_port_add(dev_port, &port_attrib, pipe_in, pipe_out);
+    expected_result = 0;
+
+    //Macro checking expected result against the actual result
+    ASSERT_EQ(ret, expected_result);
+
+}

--- a/unit-test/mock/mock_lld_dpdk_port.h
+++ b/unit-test/mock/mock_lld_dpdk_port.h
@@ -21,3 +21,15 @@ MOCK_GLOBAL_FUNC1(pipeline_find, struct pipeline *(const char *name));
 //in src/lld/dpdk/infra/dpdk_obj.c
 MOCK_GLOBAL_FUNC1(mempool_find, struct mempool *(const char *name));
 
+//Mocking tap_find function which is defined
+//in src/lld/dpdk/infra/dpdk_obj.c
+MOCK_GLOBAL_FUNC1(tap_find, struct tap *(const char *name));
+
+//Mocking link_find function which is defined
+//in src/lld/dpdk/infra/dpdk_obj.c
+MOCK_GLOBAL_FUNC1(link_find, struct link *(const char *name));
+
+//Mocking ring_find function which is defined
+//in src/lld/dpdk/infra/dpdk_obj.c
+MOCK_GLOBAL_FUNC1(ring_find, struct ring *(const char *name));
+


### PR DESCRIPTION
Add a support to build dpdk pipeline using dynamic library file instead using .spec file.

Signed-off-by: Anand Sunkad <anand.sunkad@intel.com>