### PR TITLE
Address rule encoding failure issue

### DIFF
--- a/src/pipe_mgr/shared/dal/dpdk/dal_tbl.c
+++ b/src/pipe_mgr/shared/dal/dpdk/dal_tbl.c
@@ -34,6 +34,7 @@ static int table_match_field_info(char *table_name,
 	int status = BF_SUCCESS;
 	int n_match;
 	int i;
+	int offset_min = INT_MAX;
 
 	n_match = meta->dpdk_table_info.n_match_fields;
 
@@ -52,8 +53,14 @@ static int table_match_field_info(char *table_name,
 			P4_SDE_FREE(meta->mf);
 			return BF_UNEXPECTED;
 		}
+
+		if (offset_min > (int)meta->mf[i].offset)
+			offset_min = meta->mf[i].offset;
+
 		meta->match_field_nbits += meta->mf[i].n_bits;
 	}
+	meta->first_offset = offset_min;
+
 	return status;
 }
 

--- a/src/pipe_mgr/shared/dal/dpdk/pipe_mgr_dpdk_ctx_util.c
+++ b/src/pipe_mgr/shared/dal/dpdk/pipe_mgr_dpdk_ctx_util.c
@@ -77,7 +77,7 @@ int pipe_mgr_dpdk_encode_match_key_and_mask(
 			return BF_UNEXPECTED;
 		}
 		mf = &meta->mf[i];
-		offset = (mf->offset - meta->mf[0].offset) >> 3;
+		offset = (mf->offset - meta->first_offset) >> 3;
 		match_bytes = (mf->n_bits >> 3) + (mf->n_bits % 8 != 0);
 
 		/* encode key value */

--- a/src/pipe_mgr/shared/dal/dpdk/pipe_mgr_dpdk_ctx_util.c
+++ b/src/pipe_mgr/shared/dal/dpdk/pipe_mgr_dpdk_ctx_util.c
@@ -96,12 +96,16 @@ int pipe_mgr_dpdk_encode_match_key_and_mask(
 			/* encode key mask */
 			memcpy(&val, &(match_spec->match_mask_bits[index_2]),
 					sizeof(uint64_t));
-			index_2 += sizeof(uint64_t);
+
+			if (!mf->is_header)
+				val = dpdk_field_hton(val, mf->n_bits);
+
 			/* Copy to entry. */
 			memcpy(&entry->key_mask[offset], (uint8_t *)&val,
 					match_bytes);
 		}
 		match_fields = match_fields->next;
+		index_2 += match_bytes;
 	}
 
 	entry->key_priority = match_spec->priority;

--- a/src/pipe_mgr/shared/dal/dpdk/pipe_mgr_dpdk_int.h
+++ b/src/pipe_mgr/shared/dal/dpdk/pipe_mgr_dpdk_int.h
@@ -69,6 +69,7 @@ struct dal_dpdk_table_metadata {
 	enum pipe_mgr_match_type match_type;
 	uint32_t match_field_nbits;
 	uint32_t action_data_size;
+	uint32_t first_offset;
 };
 
 struct dal_dpdk_value_lookup_metadata {


### PR DESCRIPTION
Encoding rule is failing when the order of match key fields in the table are differ than what they appear in header.

Issue is because while calculating offset value, considering first match key field position as base offset irrespective of where that field exist in the header, which leads to rule encoding failure.

To mitigate the issue, calculating base offset value properly.

Signed-off-by: Anand Sunkad <anand.sunkad@intel.com>