### PR TITLE
Connection tracking timer support

### DIFF
--- a/bf_switchd/bf_switchd.c
+++ b/bf_switchd/bf_switchd.c
@@ -459,6 +459,11 @@ static bf_status_t bf_switchd_init_device_profile(
       for (s = 0; s < p4_pipeline->num_pipes_in_scope; s++) {
         dev_profile_pipeline->pipe_scope[s] = p4_pipeline->pipe_scope[s];
       }
+      // CT timer values
+      dev_profile_pipeline->num_ct_timer_profiles =
+	      p4_pipeline->num_ct_timer_profiles;
+      memcpy(dev_profile_pipeline->bf_ct_timeout, p4_pipeline->ct_timeout,
+		      sizeof(int) * dev_profile_pipeline->num_ct_timer_profiles);
     }
   }
 

--- a/bf_switchd/lib/bf_switchd_lib_init.h
+++ b/bf_switchd/lib/bf_switchd_lib_init.h
@@ -61,6 +61,7 @@ typedef struct switch_asic_s {
 
 #define BF_SWITCHD_MAX_PIPES 4
 #define BF_SWITCHD_MAX_MEMPOOL_OBJS 2
+#define BF_SWITCHD_MAX_CT_TIMER_PROFILES 8
 #define BF_SWITCHD_MAX_P4_PROGRAMS BF_SWITCHD_MAX_PIPES
 #define BF_SWITCHD_MAX_P4_PIPELINES BF_SWITCHD_MAX_PIPES
 typedef struct p4_pipeline_config_s {
@@ -73,6 +74,8 @@ typedef struct p4_pipeline_config_s {
   int num_pipes_in_scope;
   int pipe_scope[BF_SWITCHD_MAX_PIPES];
   struct mirror_config_s mir_cfg;
+  int num_ct_timer_profiles;
+  int ct_timeout[BF_SWITCHD_MAX_CT_TIMER_PROFILES];
 } p4_pipeline_config_t;
 
 typedef struct p4_programs_s {

--- a/bf_switchd/switch_config.c
+++ b/bf_switchd/switch_config.c
@@ -407,7 +407,13 @@ static void switch_p4_pipeline_config_init(const char *install_dir,
             cJSON *pipe_scope_obj = cJSON_GetArrayItem(pipe_scope_arr, s);
             p4_pipeline->pipe_scope[s] = pipe_scope_obj->valueint;
           }
-        }
+	  cJSON *ct_timeout_arr = cJSON_GetObjectItem(p4_pipeline_obj, "ct_timeout");
+	  p4_pipeline->num_ct_timer_profiles = cJSON_GetArraySize(ct_timeout_arr);
+	  for (j = 0; j < p4_pipeline->num_ct_timer_profiles; ++j) {
+		  cJSON *ct_timeout_obj = cJSON_GetArrayItem(ct_timeout_arr, j);
+		  p4_pipeline->ct_timeout[j] = ct_timeout_obj->valueint;
+	  }
+	}
       }
       /* Print config */
       printf("P4 profile for dev_id %d\n", device);
@@ -444,6 +450,11 @@ static void switch_p4_pipeline_config_init(const char *install_dir,
             }
             printf("]\n");
           }
+	  printf("  Timer values [");
+	  for (j = 0; j< p4_pipeline->num_ct_timer_profiles; ++j) {
+		printf("%d ", p4_pipeline->ct_timeout[j]);
+	}
+	  printf("]\n");
 	  printf("  Mirror Config\n");
 	  printf("    n_slots: %u \n", p4_pipeline->mir_cfg.n_slots);
 	  printf("    n_sessions: %u \n", p4_pipeline->mir_cfg.n_sessions);

--- a/examples/pna_tcp_connection_tracking/pna_tcp_connection_tracking.conf
+++ b/examples/pna_tcp_connection_tracking/pna_tcp_connection_tracking.conf
@@ -38,6 +38,16 @@
                                 2,
                                 3
                             ],
+                            "ct_timeout": [
+                                10,
+                                30,
+                                60,
+                                120,
+                                300,
+                                43200,
+                                120,
+                                120
+                            ],
                             "path": "share/tofinopd/pna_tcp_connection_tracking"
                         }
                     ]

--- a/include/dvm/bf_drv_profile.h
+++ b/include/dvm/bf_drv_profile.h
@@ -36,6 +36,7 @@
 #define PCIE_DOMAIN_BDF_LEN 16
 #define IOMMU_GRP_NUM_LEN 6
 #define MAX_EAL_LEN 512
+#define MAX_CT_TIMER_PROFILES 8
 
 struct mirror_config_s {
 	/* Number of packet mirroring slots. */
@@ -59,6 +60,8 @@ typedef struct bf_p4_pipeline {
   int num_pipes_in_scope;            // num pipes in scope
   int pipe_scope[MAX_P4_PIPELINES];  // logical pipe list
   struct mirror_config_s mir_cfg;   // dpdk mirror profile cfg.
+  int num_ct_timer_profiles;
+  int bf_ct_timeout[MAX_CT_TIMER_PROFILES];
 } bf_p4_pipeline_t;
 
 typedef struct asic_fw_profile {

--- a/src/pipe_mgr/shared/dal/dpdk/dal_init.c
+++ b/src/pipe_mgr/shared/dal/dpdk/dal_init.c
@@ -53,7 +53,7 @@ int dal_enable_pipeline(bf_dev_id_t dev_id,
 	struct pipeline *pipe;
 	const char *err_msg;
 	uint32_t err_line;
-	int status;
+	int status, j;
 	uint32_t i, n_ports;
 	struct rte_swx_ctl_pipeline_info pipeline;
 	uint64_t net_port_mask;
@@ -130,6 +130,23 @@ create_pipeline:
 	if (status) {
 		LOG_ERROR("error :thread pipeline enable");
 		return BF_UNEXPECTED;
+	}
+	// SET the CT timer values from conf file
+	for (i = 0; i < pipeline.n_learners; i++) {
+		for (j = 0; j < profile->num_ct_timer_profiles; j++ ){
+			if(profile->bf_ct_timeout[j] <= 0) {
+				LOG_TRACE("Timer with Negative not allowed %d\n",
+						profile->bf_ct_timeout[j]);
+				continue;
+			}
+			status = rte_swx_ctl_pipeline_learner_timeout_set(pipe->p,
+                                       i, j, profile->bf_ct_timeout[j]);
+			if (status) {
+				LOG_ERROR("set CT timer failed for id %d "
+						"value %d\n", j,
+						profile->bf_ct_timeout[j]);
+			}
+		}
 	}
 
 	LOG_TRACE("Exit %s", __func__);

--- a/src/pipe_mgr/shared/infra/pipe_mgr_int.h
+++ b/src/pipe_mgr/shared/infra/pipe_mgr_int.h
@@ -402,6 +402,8 @@ struct pipe_mgr_profile {
 	int schema_version[P4_SDE_VERSION_LEN];
 
 	/* Currently mod_addr action has 24 bit to specify */
+        int num_ct_timer_profiles;
+        int bf_ct_timeout[MAX_CT_TIMER_PROFILES];
 };
 
 struct pipe_mgr_dev {

--- a/src/pipe_mgr/shared/infra/pipe_mgr_shared_init.c
+++ b/src/pipe_mgr/shared/infra/pipe_mgr_shared_init.c
@@ -155,6 +155,10 @@ int pipe_mgr_set_profile(int dev_id,
 			PIPE_MGR_CFG_FILE_LEN - 1);
 		profile->core_id = p4_pipeline->core_id;
 		profile->fast_clone = p4_pipeline->mir_cfg.fast_clone;
+		profile->num_ct_timer_profiles =
+			p4_pipeline->num_ct_timer_profiles;
+		memcpy(profile->bf_ct_timeout, p4_pipeline->bf_ct_timeout,
+				sizeof(int) * profile->num_ct_timer_profiles);
 	}
 	if (parsed_pipe_ctx)
 		profile->pipe_ctx = *parsed_pipe_ctx;


### PR DESCRIPTION
Added support to configure the timer values from the conf file.
Added a new timer array in conf file to hold the timer values.
[CT_timer_unit.txt](https://github.com/p4lang/p4-dpdk-target/files/9775344/CT_timer_unit.txt)
[CT_timer_unit_test.txt](https://github.com/p4lang/p4-dpdk-target/files/9775348/CT_timer_unit_test.txt)
