### PR TITLE
NVFMSA-5808 [BUG] | Fixed function manager fails with p4ovs set pipeline 

### DIFF
--- a/src/fixed_function/fixed_function_init.c
+++ b/src/fixed_function/fixed_function_init.c
@@ -21,7 +21,9 @@
 #include "fixed_function/fixed_function_log.h"
 #include <dvm/bf_drv_intf.h>
 
+/* Global defines */
 static struct fixed_function_ctx *fixed_function_ctx_obj;
+bool is_skip_fix_func_mgr_init = false; //fixed func mgr init status
 
 /*
  * Get the Fixed Function Context Object
@@ -68,7 +70,7 @@ struct fixed_function_table_ctx *get_fixed_function_table_ctx(struct fixed_funct
 			return &(ff_mgr_ctx->table_ctx[i]);
 	}
 
-	LOG_ERROR("%s : Fixed Function Table Ctx not found", __func__);	
+	LOG_ERROR("%s : Fixed Function Table Ctx not found", __func__);
 	return NULL;
 }
 
@@ -192,7 +194,16 @@ bf_status_t fixed_function_dev_add(bf_dev_id_t dev_id,
 
         LOG_TRACE("Entering %s", __func__);
 
-        status = fixed_function_ctx_import(dev_id, profile);
+	/* TODO: register all fixed function manager such as port/crypto
+	   * with fixed function manager and respective device add should
+	   * be triggered as part of fixed function device add instead of
+	   * adding individual managers (such as crypto/port).
+	   */
+	/* skip fixed function manager init if initialised */
+	if (!is_skip_fix_func_mgr_init) {
+		status = fixed_function_ctx_import(dev_id, profile);
+		is_skip_fix_func_mgr_init = true;
+	}
 
 	LOG_TRACE("Exiting %s", __func__);
         return status;

--- a/src/tdi_rt/tdi_common/tdi_rt_init.cpp
+++ b/src/tdi_rt/tdi_common/tdi_rt_init.cpp
@@ -88,11 +88,11 @@ std::vector<tdi::ProgramConfig> convertDevProfileToDeviceConfig(
     const std::vector<std::string> &tdi_fixed_json_path_vec) {
   // tracks P4 programs with valid bf-rt.json of their own
   uint32_t num_valid_p4_programs = 0;
+  std::vector<std::string> tdi_p4_json_vect(tdi_fixed_json_path_vec);
 
   std::vector<tdi::ProgramConfig> program_config_vec;
   for (int i = 0; i < dev_profile->num_p4_programs; i++) {
     std::string prog_name(dev_profile->p4_programs[i].prog_name);
-    std::vector<std::string> tdi_p4_json_vect(tdi_fixed_json_path_vec);
     std::vector<tdi::P4Pipeline> p4_pipelines;
     // If bf-rt.json doesn't exist, then continue the loop
     if (dev_profile->p4_programs[i].bfrt_json_file == nullptr) {
@@ -147,7 +147,12 @@ std::vector<tdi::ProgramConfig> convertDevProfileToDeviceConfig(
     // fake p4 program name "$SHARED".
     std::vector<tdi::P4Pipeline> dummy;
     std::string prog_name = "$SHARED";
-    program_config_vec.emplace_back(prog_name, tdi_fixed_json_path_vec, dummy);
+
+    // append fixed function TDI.json files
+    for (int j = 0; j < dev_profile->num_fixed_functions; j++) {
+	tdi_p4_json_vect.push_back(dev_profile->fixed_functions[j].tdi_json);
+    }
+    program_config_vec.emplace_back(prog_name, tdi_p4_json_vect, dummy);
   }
   return program_config_vec;
 }


### PR DESCRIPTION
NVFMSA-5808 [BUG] | Fixed function manager fails with p4ovs set pipeline (#517)

Issue:
fixed function manager fails with p4-ovs set pipeline command.

Root Cause:
Fixed function manager is initialized with p4ovs server startup. With set pipeline command also, fixed function manager is getting initialized, this leads to device add failure.

Fix:
Added a global variable "is_skip_fix_func_mgr_init" to avoid re-initilization of fix function manager.
Initially this flag set to "false", set to "true" after fixed function manager initialization.

And also, adding fixed function tdi.json files with program name $SHARED and parsing as part of TDI device addition when p4 program/pipeline not set.