### PR TITLE
Fix return status in case of duplicate entry and update zlog-cfg

### DIFF
--- a/src/pipe_mgr/shared/features/pipe_mgr_mat.c
+++ b/src/pipe_mgr/shared/features/pipe_mgr_mat.c
@@ -397,7 +397,7 @@ int pipe_mgr_mat_ent_add(u32 sess_hdl,
 
 		if (exists) {
 			LOG_ERROR("duplicate entry found in table = %s", tbl->ctx.name);
-			status = BF_UNEXPECTED;
+			status = BF_ALREADY_EXISTS;
 			goto cleanup;
 		}
 	}
@@ -494,7 +494,7 @@ int pipe_mgr_mat_ent_del_by_match_spec(u32 sess_hdl,
 		if (!exists) {
 			LOG_ERROR("entry not found in table = %s",
 					tbl->ctx.name);
-			status = BF_UNEXPECTED;
+			status = BF_OBJECT_NOT_FOUND;
 			goto cleanup;
 		}
 	}

--- a/zlog-cfg
+++ b/zlog-cfg
@@ -40,6 +40,9 @@ BF_PAL.DEBUG "p4_driver.log", 5M * 5 ;file_format
 BF_PM.ERROR >stdout;console_format
 BF_PM.DEBUG "p4_driver.log", 5M * 5 ;file_format
 
+BF_BFRT.ERROR >stdout;console_format
+BF_BFRT.DEBUG "p4_driver.log", 5M * 5 ;file_format
+
 KRNLMON.ERROR >stdout;console_format
 KRNLMON.DEBUG "krnlmon.log", 5M * 5 ;file_format
 

--- a/zlog-cfg
+++ b/zlog-cfg
@@ -40,8 +40,14 @@ BF_PAL.DEBUG "p4_driver.log", 5M * 5 ;file_format
 BF_PM.ERROR >stdout;console_format
 BF_PM.DEBUG "p4_driver.log", 5M * 5 ;file_format
 
-BF_BFRT.ERROR >stdout;console_format
-BF_BFRT.DEBUG "p4_driver.log", 5M * 5 ;file_format
+KRNLMON.ERROR >stdout;console_format
+KRNLMON.DEBUG "krnlmon.log", 5M * 5 ;file_format
+
+OVSP4RT.ERROR >stdout;console_format
+OVSP4RT.DEBUG "ovsp4rt.log", 5M * 5 ;file_format
+
+INFRAP4D.ERROR >stdout;console_format
+INFRAP4D.DEBUG "infrap4d.log", 5M * 5 ;file_format
 
 *.ERROR	 >syslog , LOG_USER
 


### PR DESCRIPTION
Return BF_ALREADY_EXISTS in case of duplicate table entry. PRint debug of table entry after adding or deleting table entry successfully. Update zlog-cfg to include krnlmon and infrap4d

Signed-off-by: Nupur Uttarwar <nupur.uttarwar@intel.com>