### PR TITLE
Fix Linux networking recipe crash

### DIFF
--- a/src/lld/dpdk/apply_patch.sh
+++ b/src/lld/dpdk/apply_patch.sh
@@ -17,7 +17,8 @@
 
 apply_patch()
 {
-	local PATCH_FILES=(0001-Copy-required-header-file-to-install-include-path.patch)
+	local
+  PATCH_FILES=(0001-Copy-required-header-file-to-install-include-path.patch 0002-pipeline-fix-validate-header-instruction.patch)
 
 	DPDK_PATH=${PWD}
 	DPDK_SRC_PATH="${DPDK_PATH}"/dpdk_src

--- a/src/lld/dpdk/patch/0002-pipeline-fix-validate-header-instruction.patch
+++ b/src/lld/dpdk/patch/0002-pipeline-fix-validate-header-instruction.patch
@@ -1,0 +1,55 @@
+From 3d80360468bea7a85909be41a459d149f95f7763 Mon Sep 17 00:00:00 2001
+From: yjangra <yogesh.jangra@intel.com>
+Date: Fri, 18 Nov 2022 09:48:20 +0530
+Subject: [PATCH] pipeline: fix validate header instruction
+
+Export function for invalidate and validate instruction are pointing
+to the function for validate header instruction export. Validate header
+instruction export function missed to update structure index.
+We updated the validate header instruction export function and added
+new function for invalidate header export instruction.
+
+Signed-off-by: Yogesh Jangra <yogesh.jangra@intel.com>
+Signed-off-by: R, Kamalakannan <kamalakannan.r@intel.com>
+---
+ lib/pipeline/rte_swx_pipeline.c | 18 +++++++++++++++++-
+ 1 file changed, 17 insertions(+), 1 deletion(-)
+
+diff --git a/lib/pipeline/rte_swx_pipeline.c b/lib/pipeline/rte_swx_pipeline.c
+index 232dafb95e..e489aebd3b 100644
+--- a/lib/pipeline/rte_swx_pipeline.c
++++ b/lib/pipeline/rte_swx_pipeline.c
+@@ -11787,6 +11787,22 @@ instr_recircid_export(struct instruction *instr, FILE *f)
+ 
+ static void
+ instr_hdr_validate_export(struct instruction *instr, FILE *f)
++{
++	fprintf(f,
++		"\t{\n"
++		"\t\t.type = %s,\n"
++		"\t\t.valid = {\n"
++		"\t\t\t.header_id = %u,\n"
++		"\t\t\t.struct_id = %u,\n"
++		"\t\t},\n"
++		"\t},\n",
++		instr_type_to_name(instr),
++		instr->valid.header_id,
++		instr->valid.struct_id);
++}
++
++static void
++instr_hdr_invalidate_export(struct instruction *instr, FILE *f)
+ {
+ 	fprintf(f,
+ 		"\t{\n"
+@@ -12455,7 +12471,7 @@ static instruction_export_t export_table[] = {
+ 	[INSTR_HDR_EMIT8_TX] = instr_io_export,
+ 
+ 	[INSTR_HDR_VALIDATE] = instr_hdr_validate_export,
+-	[INSTR_HDR_INVALIDATE] = instr_hdr_validate_export,
++	[INSTR_HDR_INVALIDATE] = instr_hdr_invalidate_export,
+ 
+ 	[INSTR_MOV] = instr_mov_export,
+ 	[INSTR_MOV_MH] = instr_mov_export,
+-- 
+2.25.1


### PR DESCRIPTION
Added the DPDK patch required for addressing the crash happening while validating the new header required for adding a new VLAN header.

Signed-off-by: Venkata Suresh Kumar P <venkata.suresh.kumar.p@intel.com>