### PR TITLE
Change PSA example p4-programs

### DIFF
--- a/examples/psa/simple_l2l3_lpm/simple_l2l3_lpm.p4
+++ b/examples/psa/simple_l2l3_lpm/simple_l2l3_lpm.p4
@@ -111,7 +111,7 @@ control ingress(
 )
 {
     action send(PortId_t port) {
-        ostd.egress_port = (PortId_t) port;
+	send_to_port(ostd, port);
     }
 
     action drop() {
@@ -121,7 +121,7 @@ control ingress(
 	action set_port_and_src_mac( PortId_t port,
                                  ethernet_addr_t src_mac,
                                  ethernet_addr_t dst_mac) {
-        ostd.egress_port = port;
+	send_to_port(ostd, port);
         hdr.ethernet.src_addr = src_mac;
         hdr.ethernet.dst_addr = dst_mac;
     }

--- a/examples/psa/simple_l2l3_wcm/simple_l2l3_wcm.p4
+++ b/examples/psa/simple_l2l3_wcm/simple_l2l3_wcm.p4
@@ -112,7 +112,7 @@ control ingress(
 )
 {
     action send(PortId_t port) {
-        ostd.egress_port = (PortId_t) port;
+	send_to_port(ostd, port);
     }
 
     action drop() {
@@ -122,7 +122,7 @@ control ingress(
 	action set_port_and_src_mac( PortId_t port,
                                  ethernet_addr_t src_mac,
                                  ethernet_addr_t dst_mac) {
-        ostd.egress_port = port;
+	send_to_port(ostd, port);
         hdr.ethernet.src_addr = src_mac;
         hdr.ethernet.dst_addr = dst_mac;
     }


### PR DESCRIPTION
Earlier by default P4 DPDK compiler used to initialize the PSA ingress drop flag to false.

As per the PSA specification, by default ingress drop flag should be set to true, so need to set drop flag false while forwarding packets.

To mitigate the issue using send_to_port, which intern take care of setting PSA ingress drop flag to false and setting egress port.

Signed-off-by: Anand Sunkad <anand.sunkad@intel.com>