### PR TITLE
Address Key_mask issue

### DIFF
--- a/src/pipe_mgr/shared/dal/dpdk/pipe_mgr_dpdk_ctx_util.c
+++ b/src/pipe_mgr/shared/dal/dpdk/pipe_mgr_dpdk_ctx_util.c
@@ -37,7 +37,7 @@ int pipe_mgr_dpdk_encode_match_key_and_mask(
 	struct pipe_mgr_dpdk_stage_table *stage_table;
 	struct pipe_mgr_match_key_fields *match_fields;
 	struct dal_dpdk_table_metadata *meta;
-	uint64_t mask = 0xffffffffffffffff;
+	uint64_t mask = (uint64_t)-1;
 	int status = BF_SUCCESS;
 	uint32_t offset;
 	int match_bytes;

--- a/src/pipe_mgr/shared/dal/dpdk/pipe_mgr_dpdk_ctx_util.c
+++ b/src/pipe_mgr/shared/dal/dpdk/pipe_mgr_dpdk_ctx_util.c
@@ -37,6 +37,7 @@ int pipe_mgr_dpdk_encode_match_key_and_mask(
 	struct pipe_mgr_dpdk_stage_table *stage_table;
 	struct pipe_mgr_match_key_fields *match_fields;
 	struct dal_dpdk_table_metadata *meta;
+	uint64_t mask = 0xffffffffffffffff;
 	int status = BF_SUCCESS;
 	uint32_t offset;
 	int match_bytes;
@@ -103,7 +104,11 @@ int pipe_mgr_dpdk_encode_match_key_and_mask(
 			/* Copy to entry. */
 			memcpy(&entry->key_mask[offset], (uint8_t *)&val,
 					match_bytes);
+		} else if (entry->key_mask) {
+			memcpy(&entry->key_mask[offset], (uint8_t *)&mask,
+			       match_bytes);
 		}
+
 		match_fields = match_fields->next;
 		index_2 += match_bytes;
 	}


### PR DESCRIPTION
When table match key fields are of different match types like EXACT match and LPM match, key mask calculated only for LPM key, which leads to key match failure.

To mitigate the issue calculating key mask for both EXACT and LPM key types.

Signed-off-by: Anand Sunkad <anand.sunkad@intel.com>