### PR TITLE
Address MTU issue.

### DIFF
--- a/include/port_mgr/dpdk/bf_dpdk_port_if.h
+++ b/include/port_mgr/dpdk/bf_dpdk_port_if.h
@@ -63,6 +63,7 @@ typedef enum bf_pm_port_dir_e {
 #define PORT_IN_BURST_SIZE 32
 #define PORT_OUT_BURST_SIZE 1
 #define PORT_MTU_MAX 65535
+#define ETH_HDR 14
 
 /**
  * DPDK Port Types

--- a/src/lld/dpdk/lld_dpdk_port.c
+++ b/src/lld/dpdk/lld_dpdk_port.c
@@ -89,7 +89,7 @@ int lld_dpdk_pipeline_tap_port_add(bf_dev_port_t dev_port,
 	    (port_attrib->port_dir == PM_PORT_DIR_RX_ONLY)) {
 		params_in.fd = tap->fd;
 		params_in.mempool = mp->m;
-		params_in.mtu = port_attrib->tap.mtu;
+		params_in.mtu = port_attrib->tap.mtu + ETH_HDR;
 		params_in.burst_size = PORT_IN_BURST_SIZE;
 		if (port_attrib->tap.mtu > PORT_MTU_MAX) {
 			LOG_ERROR("MTU for Tap Port %s is greater than max limit\n",


### PR DESCRIPTION
Setting DPDK TAP interface MTU as same as linux net_tap interface MTU value, leads for DPDK tap fd to truncate ethernet header size.

To mitigate the issue set DPDK TAP interface MTU value to linux net_tap interface MTU value + eth header size.

Signed-off-by: Anand Sunkad <anand.sunkad@intel.com>