### PR TITLE
Address Extern type parsing error

### DIFF
--- a/include/ctx_json/ctx_json_utils.h
+++ b/include/ctx_json/ctx_json_utils.h
@@ -860,6 +860,11 @@
 #define CTX_JSON_EXTERN_ATTRIBUTE_TABLE_ID   "table_id"
 #define CTX_JSON_EXTERN_TYPE_COUNTER      "Counter"
 #define CTX_JSON_EXTERN_TYPE_REGISTER      "Register"
+#define CTX_JSON_EXTERN_TYPE_DIRECT_COUNTER         "DirectCounter"
+#define CTX_JSON_EXTERN_TYPE_METER                  "Meter"
+#define CTX_JSON_EXTERN_TYPE_DIRECT_METER           "DirectMeter"
+#define CTX_JSON_EXTERN_TYPE_HASH                   "Hash"
+#define CTX_JSON_EXTERN_TYPE_INTERNET_CHECK_SUM     "InternetCheckSum"
 
 #define CTX_JSON_EXTERN_ATTR_TYPE_BYTES               "bytes"
 #define CTX_JSON_EXTERN_ATTR_TYPE_PACKETS             "packets"

--- a/src/pipe_mgr/core/dal/dpdk/pipe_mgr_ctx_dpdk_json.c
+++ b/src/pipe_mgr/core/dal/dpdk/pipe_mgr_ctx_dpdk_json.c
@@ -531,6 +531,31 @@ static bf_status_t ctx_json_parse_externs_entry (
 		entry->type = EXTERNS_REGISTER;
 	}
 
+	if (!strncmp(target_type, CTX_JSON_EXTERN_TYPE_DIRECT_COUNTER,
+		     sizeof(CTX_JSON_EXTERN_TYPE_DIRECT_COUNTER))) {
+		entry->type = EXTERNS_DIRECT_COUNTER;
+	}
+
+	if (!strncmp(target_type, CTX_JSON_EXTERN_TYPE_METER,
+		     sizeof(CTX_JSON_EXTERN_TYPE_METER))) {
+		entry->type = EXTERNS_METER;
+	}
+
+	if (!strncmp(target_type, CTX_JSON_EXTERN_TYPE_DIRECT_METER,
+		     sizeof(CTX_JSON_EXTERN_TYPE_DIRECT_METER))) {
+		entry->type = EXTERNS_DIRECT_METER;
+	}
+
+	if (!strncmp(target_type, CTX_JSON_EXTERN_TYPE_HASH,
+		     sizeof(CTX_JSON_EXTERN_TYPE_HASH))) {
+		entry->type = EXTERNS_HASH;
+	}
+
+	if (!strncmp(target_type, CTX_JSON_EXTERN_TYPE_INTERNET_CHECK_SUM,
+		     sizeof(CTX_JSON_EXTERN_TYPE_INTERNET_CHECK_SUM))) {
+		entry->type = EXTERNS_INTERNET_CHECK_SUM;
+	}
+
 	if (entry->type == EXTERNS_COUNTER) {
 		err |= bf_cjson_get_string(extern_attr_cjson,
 				CTX_JSON_EXTERN_ATTRIBUTE_TYPE,

--- a/src/pipe_mgr/shared/infra/pipe_mgr_int.h
+++ b/src/pipe_mgr/shared/infra/pipe_mgr_int.h
@@ -288,7 +288,12 @@ enum externs_attr_type {
 enum externs_type {
 	/* externs type counter */
 	EXTERNS_COUNTER = 0,
-	EXTERNS_REGISTER = 1
+	EXTERNS_REGISTER = 1,
+	EXTERNS_DIRECT_COUNTER = 2,
+	EXTERNS_METER = 3,
+	EXTERNS_DIRECT_METER = 4,
+	EXTERNS_HASH = 5,
+	EXTERNS_INTERNET_CHECK_SUM = 6
 };
 
 /* externs json information of the table. */


### PR DESCRIPTION
Failing to parse extern types which are not defined in SDE leads to device add failure.

To mitigate the issue defined all extern types emitted by compiler So that extern type parsing goes through successfully.