### PR TITLE
target_name to be passed to dpdk entry_add API

### DIFF
--- a/src/pipe_mgr/shared/dal/dpdk/dal_adt.c
+++ b/src/pipe_mgr/shared/dal/dpdk/dal_adt.c
@@ -122,7 +122,7 @@ int dal_table_adt_ent_add(u32 sess_hdl,
 		goto error;
 	}
 
-	status = rte_swx_ctl_pipeline_table_entry_add(ctl, mat_ctx->name,
+	status = rte_swx_ctl_pipeline_table_entry_add(ctl, mat_ctx->target_table_name,
 						      entry);
 	if (status) {
 		LOG_ERROR("rte_swx_ctl_pipeline_table_entry_add");

--- a/src/pipe_mgr/shared/dal/dpdk/dal_counters.c
+++ b/src/pipe_mgr/shared/dal/dpdk/dal_counters.c
@@ -306,7 +306,7 @@ dal_cnt_read_flow_direct_counter_set(void *dal_data, void *res_data,
         }
 
         if (ctx_obj->num_externs_tables == 0) {
-                LOG_ERROR("[%s]:externs object/entry table empty", __func__);
+                LOG_TRACE("[%s]:externs object/entry table empty", __func__);
                 return BF_SUCCESS;
         }
 
@@ -325,6 +325,16 @@ dal_cnt_read_flow_direct_counter_set(void *dal_data, void *res_data,
                           ctx_obj->externs_tables_name[itr]);
                 return BF_OBJECT_NOT_FOUND;
         }
+
+		if(itr == ctx_obj->num_externs_tables) {
+			LOG_TRACE("Table doesn't have any externs");
+			return BF_SUCCESS;
+		}
+
+		if(externs_entry->type != EXTERNS_COUNTER) {
+			LOG_TRACE("Not a Counter extern");
+			return BF_SUCCESS;
+		}
 
         switch (externs_entry->attr_type) {
         case EXTERNS_ATTR_TYPE_BYTES:

--- a/src/pipe_mgr/shared/dal/dpdk/dal_mat.c
+++ b/src/pipe_mgr/shared/dal/dpdk/dal_mat.c
@@ -155,7 +155,7 @@ int dal_table_ent_add(u32 sess_hdl,
 		}
 	}
 
-	status = rte_swx_ctl_pipeline_table_entry_add(pipe->ctl, mat_ctx->name
+	status = rte_swx_ctl_pipeline_table_entry_add(pipe->ctl, mat_ctx->target_table_name
 						      , entry);
 
 	if (status) {


### PR DESCRIPTION
Two issues are addressed here:
entryAdd issue: dpdk is expecting target_table_name instead of table name.
entryGet issue: There is a bug in entryGet flow, where there are few checks missing before fetching counters.