### PR TITLE
Workaround unexpected compilation bug

### DIFF
--- a/src/pipe_mgr/shared/dal/dpdk/dal_init.c
+++ b/src/pipe_mgr/shared/dal/dpdk/dal_init.c
@@ -117,6 +117,15 @@ int dal_enable_pipeline(bf_dev_id_t dev_id,
 		LOG_TRACE("Running command: %s\n", buffer);
 		status = system(buffer);
 		if (status) {
+			LOG_ERROR("%s line:%d  Command (%s) failed with exit code: %d, with errno: %d\n",
+				  __func__, __LINE__, buffer, status, errno);
+		}
+		// TODO: Ideally, we should check whether status is 0 below. But
+		// sometimes the returned status code is -1, even when the .o file is
+		// generated properly. Checking file existence is a temporary
+		// workaround. Need to further investigate and solve this issue.
+		fd = fopen(o_filepath, "r");
+		if (!fd) {
 			LOG_ERROR("%s line:%d  Cannot generate %s file\n",
 				  __func__, __LINE__, o_filepath);
 			return BF_INTERNAL_ERROR;
@@ -128,13 +137,11 @@ int dal_enable_pipeline(bf_dev_id_t dev_id,
 		LOG_TRACE("Running command: %s\n", buffer);
 		status = system(buffer);
 		if (status) {
-			LOG_ERROR("%s line:%d  Command (%s) failed with exit code: %d\n",
-				  __func__, __LINE__, buffer, status);
+			LOG_ERROR("%s line:%d  Command (%s) failed with exit code: %d, with errno: %d\n",
+				  __func__, __LINE__, buffer, status, errno);
 		}
 		// TODO: Ideally, we should check whether status is 0 below. But
-		// sometimes the returned status code is -1, even when the .so file is
-		// generated properly. Checking file existence is a temporary
-		// workaround. Need to further investigate and solve this issue.
+		// sometimes we have the same issue like the one above for the .so
 		fd = fopen(so_filepath, "r");
 		if (!fd) {
 			LOG_ERROR("%s line:%d  Cannot generate %s file\n",


### PR DESCRIPTION
I am working on a CI pipeline for p4c-dpdk and dpdk swx [here](https://github.com/p4lang/p4c/pull/4072). I found an unexpected problem that happens by chance. It is a compilation problem, which seems have already been discovered before yet not fully fixed. I workaround it with the same approach as the previously discovered one.

Here is the log showing the `.o` file was not generated while it was actually generated:

```
...
2023-08-08 11:32:15.539210 INFO  BF_PORT Exit port_mgr_config_import
2023-08-08 11:32:15.664004 ERROR BF_PIPE STATUS: -1
2023-08-08 11:32:15.664158 ERROR BF_PIPE dal_enable_pipeline line:122  Cannot generate /tmp/p4.o file  

2023-08-08 11:32:15.664187 ERROR BF_PIPE Failed to Build Pipeline pipe
2023-08-08 11:32:15.664210 ERROR BF_DVM Device add handling failed for dev 0, sts Internal error (22), Client pipe-mgr 
2023-08-08 11:32:15.664228 ERROR BF_DVM Device add failed for dev 0, sts Internal error (22)
2023-08-08 11:32:15.664286 INFO  BF_PORT Entering port_mgr_dev_remove
2023-08-08 11:32:15.664321 INFO  BF_PAL STUB fixed_function_dev_remove
2023-08-08 11:32:15.664335 INFO  BF_LLD Entering dummy STUB:lld_dev_remove
...
```