### PR TITLE
Update smoke test TDI commands to enable pipeline

### DIFF
--- a/e2e-test/suites/pna/basicfwd/cmds_bfshell.py
+++ b/e2e-test/suites/pna/basicfwd/cmds_bfshell.py
@@ -16,7 +16,7 @@ for port_id in range(4):
     )
 
 # Enable TDI program
-tdi.main.enable()
+tdi.enable()
 
 # Add entries
 control = tdi.main.pipe.MainControl


### PR DESCRIPTION
It appears that the smoke test now has an invalid command which causes it to fail.

This updates it from `tdi.main.enable()` to `tdi.enable()` to allow it to pass