### PR TITLE
Add Ubuntu 24.04 support: install_p4_dpdk and CI

### DIFF
--- a/.github/workflows/build_p4sde_ci.yml
+++ b/.github/workflows/build_p4sde_ci.yml
@@ -14,7 +14,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build_p4dpdk_ubuntu:
+  build_p4dpdk_ubuntu_22:
     timeout-minutes: 30
     runs-on: ubuntu-22.04
     steps:
@@ -27,6 +27,32 @@ jobs:
         run: |
               sudo apt update -y
               python install_dep.py
+      - name: 'Compile p4sde dpdk target'
+        run: |
+             export SDE=${GITHUB_WORKSPACE}
+             mkdir install
+             export SDE_INSTALL=${GITHUB_WORKSPACE}/install
+             ./autogen.sh
+             ./configure --prefix=$SDE_INSTALL
+             make 
+             make install
+
+  build_p4dpdk_ubuntu_24_04:
+    timeout-minutes: 30
+    runs-on: ubuntu-24.04
+    steps:
+      - name: 'Checkout'
+        uses: actions/checkout@v3
+        with:
+             submodules: 'recursive'
+      - name: 'Install dependencies'
+        working-directory: ./tools/setup
+        run: |
+              sudo apt update -y
+              sudo apt install -y pkg-config python3-pip libedit-dev
+              pip3 install setuptools
+              pip3 install distro
+              python3 install_dep.py
       - name: 'Compile p4sde dpdk target'
         run: |
              export SDE=${GITHUB_WORKSPACE}

--- a/.github/workflows/build_p4sde_ci.yml
+++ b/.github/workflows/build_p4sde_ci.yml
@@ -37,7 +37,7 @@ jobs:
              make 
              make install
 
-  build_p4dpdk_ubuntu_24_04:
+  build_p4dpdk_ubuntu_24:
     timeout-minutes: 30
     runs-on: ubuntu-24.04
     steps:

--- a/install_p4_dpdk.sh
+++ b/install_p4_dpdk.sh
@@ -38,6 +38,18 @@ check_and_install_pkgs() {
     fi
 }
 
+install_deps_ubuntu_2404() {
+    print_step "Checking Ubuntu version..."
+    if [ -f /etc/os-release ]; then
+        source /etc/os-release
+        if [[ "$VERSION_ID" == "24.04" ]]; then
+            IS_24_04="true"
+        else
+            IS_24_04="false"
+        fi
+    fi
+}
+
 
 # ------------------------------------------------------------
 # 1. Base directories
@@ -58,7 +70,14 @@ print_step "0/5 Checking dependencies..."
 # https://askubuntu.com/questions/1275842/install-wireshark-without-confirm
 echo "wireshark-common wireshark-common/install-setuid boolean true" | sudo debconf-set-selections
 sudo DEBIAN_FRONTEND=noninteractive apt-get -y install wireshark tshark
- check_and_install "pip3" "python3-pip"
+
+install_deps_ubuntu_2404
+
+if [[ "$IS_24_04" == "true" ]]; then
+    sudo apt update
+    sudo apt install -y libedit-dev pkg-config
+fi
+
 check_and_install "pip3" "python3-pip"
 check_and_install "autoreconf" "autoconf automake libtool pkg-config autoconf-archive automake"
 check_and_install "cmake" "cmake" 
@@ -86,6 +105,9 @@ source "$SDE/.venv/bin/activate"
 
 cd "$SDE/p4-dpdk-target/tools/setup"
 source ./p4sde_env_setup.sh "$SDE"
+if [[ "$IS_24_04" == "true" ]]; then
+    pip3 install setuptools
+fi
 pip3 install distro
 python3 install_dep.py
 

--- a/install_p4_dpdk.sh
+++ b/install_p4_dpdk.sh
@@ -22,7 +22,6 @@ check_and_install() {
     # Check if command exists (for executables)
     if ! command -v "$cmd" >/dev/null 2>&1; then
         echo -e "${YELLOW}$cmd not found.${NC}"
-        sudo apt update
         sudo apt install -y $pkgs
     fi
  }
@@ -33,7 +32,6 @@ check_and_install_pkgs() {
         echo -e "${GREEN}$pkgs is already installed.${NC}"
     else
         echo -e "${YELLOW}$pkgs not found. Installing...${NC}"
-        sudo apt update
         sudo apt install -y "$pkgs"
     fi
 }
@@ -64,6 +62,9 @@ mkdir -p "$SDE_INSTALL"
 # 0. Check Dependencies (install if missing)
 # ------------------------------------------------------------
 print_step "0/5 Checking dependencies..."
+
+sudo apt-get update -y && sudo apt-get upgrade -y
+
 # Install Wireshark and tshark on Ubuntu system without having to
 # answer _any_ questions interactively, except perhaps providing your
 # password when prompted by 'sudo'.
@@ -74,7 +75,6 @@ sudo DEBIAN_FRONTEND=noninteractive apt-get -y install wireshark tshark
 install_deps_ubuntu_2404
 
 if [[ "$IS_24_04" == "true" ]]; then
-    sudo apt update
     sudo apt install -y libedit-dev pkg-config
 fi
 
@@ -99,7 +99,7 @@ cd $SDE
 # ------------------------------------------------------------
 print_step "2/5 Installing system dependencies..."
 
-sudo apt update && sudo apt upgrade && sudo apt install -y python3-venv python3-full
+sudo apt-get install -y python3-venv python3-full
 python3 -m venv "$SDE/.venv"
 source "$SDE/.venv/bin/activate"
 


### PR DESCRIPTION
This PR extends the install_p4_dpdk script to work on Ubuntu 24.04. I also added a CI job to verify it works on Ubuntu 24.04.

[p4_dpdk_2404_success.txt](https://github.com/user-attachments/files/25328581/p4_dpdk_2404_success.txt)
